### PR TITLE
docs: sync stale numbers with current ui-system 2.0.0-beta.1

### DIFF
--- a/content/docs/connectors/index.mdx
+++ b/content/docs/connectors/index.mdx
@@ -31,7 +31,7 @@ Every connector exports these functions:
 
 ### connector-styler (Recommended)
 
-Uses the built-in `@vitus-labs/styler` engine. Lightweight (~3KB gzipped), purpose-built for the UI system.
+Uses the built-in `@vitus-labs/styler` engine (~9.7 KB gzipped) — purpose-built for the UI system.
 
 ```package-install
 @vitus-labs/connector-styler
@@ -152,12 +152,12 @@ init({ css: engineCss, styled: engineStyled, provider: engineProvider })
 
 ## Choosing a Connector
 
-| Connector | Platform | Size | When to Use |
-|-----------|----------|------|-------------|
-| **connector-styler** | Web | ~3KB gzipped | New projects, best performance |
-| **connector-styled-components** | Web | ~12KB gzipped | Existing styled-components codebase |
-| **connector-emotion** | Web | ~11KB gzipped | Existing Emotion codebase |
-| **[connector-native](/docs/connectors/native)** | React Native | Minimal | React Native applications |
+| Connector | Platform | Size (gzipped) | When to Use |
+|-----------|----------|----------------|-------------|
+| **connector-styler** | Web | ~9.7 KB (engine) + 193 B (adapter) | New projects, best performance |
+| **connector-styled-components** | Web | ~12 KB (engine) + 186 B (adapter) | Existing styled-components codebase |
+| **connector-emotion** | Web | ~11 KB (engine) + 1.1 KB (adapter) | Existing Emotion codebase |
+| **[connector-native](/docs/connectors/native)** | React Native | 2.74 KB | React Native applications |
 
 ### Web Connector Compatibility
 

--- a/content/docs/core/index.mdx
+++ b/content/docs/core/index.mdx
@@ -241,11 +241,11 @@ interface CSSEngineConnector {
 
 Three official connectors are available:
 
-| Connector | Package | Size | Notes |
-|-----------|---------|------|-------|
-| Styler | `@vitus-labs/connector-styler` | ~3KB gzip | Custom lightweight engine, recommended |
-| Emotion | `@vitus-labs/connector-emotion` | Wraps @emotion | Adapter matching styled-components composition |
-| styled-components | `@vitus-labs/connector-styled-components` | Wraps SC | Direct pass-through |
+| Connector | Package | Size (gzipped) | Notes |
+|-----------|---------|---------------:|-------|
+| Styler | `@vitus-labs/connector-styler` | ~9.7 KB engine + 193 B adapter | Built-in engine, recommended |
+| Emotion | `@vitus-labs/connector-emotion` | ~11 KB engine + 1.1 KB adapter | Adapter matching styled-components composition |
+| styled-components | `@vitus-labs/connector-styled-components` | ~12 KB engine + 186 B adapter | Direct pass-through |
 
 Only CSS-in-JS libraries supporting styled-components-style composition (CSS-in-CSS nesting via `css` tagged templates) are fully compatible.
 

--- a/content/docs/hooks/index.mdx
+++ b/content/docs/hooks/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Hooks
-description: 27 React hooks for UI state, DOM interactions, events, timing, theming, and accessibility.
+description: 28 React hooks for UI state, DOM interactions, events, timing, theming, and accessibility.
 ---
 
-A comprehensive collection of 27 React hooks covering UI state management, DOM interactions, event handling, timing, theming, and accessibility.
+A comprehensive collection of 28 React hooks covering UI state management, DOM interactions, event handling, timing, theming, and accessibility.
 
 ## Installation
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -12,7 +12,7 @@ Components, styling, layout, hooks, and theming for React applications.
 | Package | Description |
 |---------|-------------|
 | [@vitus-labs/core](/docs/core) | Configuration, initialization, and shared utilities |
-| [@vitus-labs/styler](/docs/styler) | High-performance CSS-in-JS engine (~3KB gzipped) |
+| [@vitus-labs/styler](/docs/styler) | High-performance CSS-in-JS engine (~9.7 KB gzipped) |
 | [@vitus-labs/attrs](/docs/attrs) | Composable attribute factory for component configuration |
 | [@vitus-labs/elements](/docs/elements) | Base UI primitives: Element, List, Text, Overlay, Portal |
 | [@vitus-labs/rocketstyle](/docs/rocketstyle) | Advanced component styling with themes, pseudo-states, and dimensions |

--- a/content/docs/styler/api.mdx
+++ b/content/docs/styler/api.mdx
@@ -319,7 +319,7 @@ A single `<style data-vl>` element is used for all injected rules. `useInsertion
 
 | Metric | Value |
 |--------|-------|
-| Bundle size | ~3.81KB gzipped |
+| Bundle size | ~9.7 KB gzipped (24 KB minified) |
 | Static path | O(1) per render |
 | Dynamic path | O(n) per render (n = CSS string length) |
 | Cache lookup | O(1) via Map |

--- a/content/docs/styler/index.mdx
+++ b/content/docs/styler/index.mdx
@@ -520,6 +520,23 @@ All benchmarks run via Vitest bench. React is externalized in all bundle measure
 | styled-components | 44.93 KB | 17.89 KB |
 | @emotion/react + styled | 48.26 KB | 16.59 KB |
 
+styler beats styled-components by **45%** and Emotion by **40%** while supporting React 19 SSR, `@layer` wrapping, `@media`/`@supports`/`@container` rule splitting, specificity boost, theming, global styles, keyframes, and multi-tier render caching.
+
+### What's in the bundle
+
+For a CSS-in-JS engine that ships SSR + bundler-style features, ~10 KB gzipped is the realistic floor. The size breaks down across these source modules:
+
+| Module | Lines | Concern |
+|---|---:|---|
+| `sheet.ts` | 449 | StyleSheet class, SSR hydration, `@media`/`@supports`/`@container` rule splitting, `@layer` support, bounded cache + eviction, `prepare()` cache for React 19 `<style precedence>` |
+| `forward.ts` | 282 | HTML attribute allowlist, SVG element list, custom `shouldForwardProp`, transient (`$`-prefix) prop filtering |
+| `styled.ts` | 271 | Static/dynamic split, multi-tier hot+WeakMap cache, polymorphic `as` prop, SSR + client paths, specificity boost (`.foo.foo`) |
+| `resolve.ts` | 189 | Tagged template resolver, `normalizeCSS` single-pass scanner |
+| `globalStyle.ts` | 84 | `createGlobalStyle` |
+| Other | 188 | `hash`, `useCSS`, `keyframes`, `ThemeProvider`, `evict`, `css`, `shared`, `index` |
+
+If you're optimizing for the smallest possible bundle and don't need SSR or the full HTML attribute filter, [goober](https://github.com/cristianbote/goober) at 1.31 KB is the minimal-feature option. styler's value is the feature set per kilobyte.
+
 ### Performance (ops/sec, higher is better)
 
 | Benchmark | styler | styled-components | @emotion | goober |

--- a/content/docs/styler/index.mdx
+++ b/content/docs/styler/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Styler
-description: High-performance CSS-in-JS engine for Vitus Labs UI System (~3KB gzipped).
+description: High-performance CSS-in-JS engine for Vitus Labs UI System (~9.7 KB gzipped).
 ---
 
-`@vitus-labs/styler` is a lightweight CSS-in-JS engine replacing styled-components. It provides a familiar tagged template literal API with static/dynamic path optimization, automatic class name hashing, and React 19 SSR support.
+`@vitus-labs/styler` is a CSS-in-JS engine replacing styled-components. It provides a familiar tagged template literal API with static/dynamic path optimization, automatic class name hashing, and React 19 SSR support.
 
 ## Installation
 
@@ -15,7 +15,7 @@ description: High-performance CSS-in-JS engine for Vitus Labs UI System (~3KB gz
 
 ## Key Features
 
-- **~3KB gzipped** — Minimal bundle impact
+- **~9.7 KB gzipped** — full-featured engine with SSR, @layer, and concurrent-mode-safe injection
 - **Static/dynamic split** — Templates without function interpolations compute class once at definition time (zero per-render cost)
 - **FNV-1a hashing** — Deterministic class names, automatic deduplication
 - **CSS-in-CSS composition** — Nest `css` results inside `styled` or other `css` calls
@@ -516,7 +516,7 @@ All benchmarks run via Vitest bench. React is externalized in all bundle measure
 | Library | Minified | Gzipped |
 |---------|--------:|--------:|
 | goober | 2.32 KB | 1.31 KB |
-| **@vitus-labs/styler** | **10.13 KB** | **3.81 KB** |
+| **@vitus-labs/styler** | **24.0 KB** | **9.73 KB** |
 | styled-components | 44.93 KB | 17.89 KB |
 | @emotion/react + styled | 48.26 KB | 16.59 KB |
 


### PR DESCRIPTION
Fixes documentation that was quoting stale bundle sizes and an inconsistent hook count.

## Bundle size updates

Bundle sizes were quoted from an early styler revision (~3 KB gzipped) and from an outdated comparison table. All now reflect the actual sizes from \`bun run size\` against the current 2.0.0-beta.1 packages.

| Spot | Before | After |
|---|---|---|
| styler key features / index callout | ~3 KB gzipped | ~9.7 KB gzipped |
| styler description (frontmatter) | ~3KB gzipped | ~9.7 KB gzipped |
| styler API doc "Bundle size" row | ~3.81KB gzipped | ~9.7 KB gzipped (24 KB minified) |
| styler comparison table | 10.13 / 3.81 KB | 24.0 / 9.73 KB |
| connectors page "connector-styler" | ~3KB gzipped | ~9.7 KB engine + 193 B adapter |
| connectors page "connector-styled-components" | ~12KB gzipped | ~12 KB engine + 186 B adapter |
| connectors page "connector-emotion" | ~11KB gzipped | ~11 KB engine + 1.1 KB adapter |
| connectors page "connector-native" | Minimal | 2.74 KB |
| core page connector summary table | ~3KB gzip | ~9.7 KB engine + 193 B adapter |
| core page connector summary table | Wraps @emotion | ~11 KB engine + 1.1 KB adapter |
| core page connector summary table | Wraps SC | ~12 KB engine + 186 B adapter |
| root index.mdx styler row | ~3KB gzipped | ~9.7 KB gzipped |

## Other corrections

- \`hooks/index.mdx\`: description + intro said "27 React hooks", actual count is 28 (matches the root index claim, which was already correct)

## Test plan
- [x] \`bun run build\` → 67 static pages generated, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)