### PR TITLE
docs: SSR-precedence default + per-breakpoint CSS delta diff

### DIFF
--- a/content/docs/styler/api.mdx
+++ b/content/docs/styler/api.mdx
@@ -153,21 +153,43 @@ Creates an isolated `StyleSheet` instance. Use for SSR per-request isolation.
 | `insertGlobal(cssText)` | `void` | Inject unscoped global CSS. Dedup by hash. |
 | `getClassName(cssText)` | `string` | Compute class name without injecting (render-phase safe). |
 | `prepare(cssText, boost?)` | `{ className, rules }` | Compute class + full rule text without injecting. For SSR `<style precedence>`. |
-| `getStyleTag()` | `string` | Complete `<style data-vl="">...</style>` tag with collected CSS. |
-| `getStyles()` | `string` | Raw collected CSS rules string (no `<style>` wrapper). |
+| `getStyleTag()` | `string` | Complete `<style data-vl="">...</style>` tag with collected CSS. **Manual mode only** — empty under the default React 19 precedence path. |
+| `getStyles()` | `string` | Raw collected CSS rules string (no `<style>` wrapper). **Manual mode only** — empty under the default precedence path. |
 | `has(className)` | `boolean` | O(1) cache lookup for dedup check. |
 | `reset()` | `void` | Clear ssrBuffer + cache. Call between server requests. |
 | `clearCache()` | `void` | Clear dedup cache only. Useful for HMR. |
 | `clearAll()` | `void` | Clear cache + ssrBuffer + remove all DOM rules. Full HMR reset. |
 | `cacheSize` (getter) | `number` | Current number of cached entries. |
 
-### SSR Pattern
+### SSR — Default (React 19 `<style precedence>`)
+
+On the server, styled components render `<style href={className} precedence="medium">` elements alongside their DOM output. React 19's streaming renderer hoists these to `<head>` automatically, dedupes by `href`, and orders them by precedence. This is the **default path — no manual style collection needed**.
+
+Precedence levels:
+- **`medium`** — Component styles (from `styled()` and `useCSS()`)
+- **`low`** — Global styles (from `createGlobalStyle()`)
+
+### Hydration
+
+On the client, `StyleSheet.mount()`:
+
+1. Looks for an existing `<style data-vl="">` element. If present, reuses its CSSOM sheet and seeds the dedup cache from any rules already inside it. Otherwise, creates a fresh empty `<style data-vl="">`.
+2. Walks every `<style data-precedence][data-href]>` tag React emitted during SSR and pre-populates the dedup cache with those `data-href` values. This is what prevents the first `useInsertionEffect` from re-injecting a rule that's already in the DOM under a precedence tag.
+3. On subsequent renders, `useInsertionEffect` cache-hits and skips insertion for any class already known.
+
+### Manual SSR Mode (legacy / streaming)
+
+For pipelines that need to collect CSS by hand (e.g. older SSR runtimes that don't process `<style precedence>`), opt in by calling `sheet.insert()` / `sheet.insertGlobal()` outside of render:
 
 ```tsx
 import { createSheet } from '@vitus-labs/styler'
 
 // Per-request isolation
 const sheet = createSheet()
+
+// Manually push rules into the buffer (NOT done automatically — the default
+// precedence path leaves ssrBuffer empty to avoid duplicate emission).
+sheet.insert('color: red;')
 
 // Render your app...
 const html = renderToString(<App />)
@@ -186,21 +208,7 @@ response.send(`<!DOCTYPE html><html><head>${styleTag}</head><body>${html}</body>
 sheet.reset()
 ```
 
-### Hydration
-
-On the client:
-1. `StyleSheet` mounts, finds existing `<style data-vl="">` in DOM
-2. Parses existing rules into the dedup cache (prevents re-injection)
-3. Reuses the DOM element for future insertions
-4. `useInsertionEffect` skips insertion for already-cached classes
-
-### React 19 Style Precedence
-
-On the server, styled components render `<style href={className} precedence="medium">` elements alongside their DOM output. React 19's streaming renderer hoists these to `<head>` automatically, providing FOUC-free delivery without manual style collection.
-
-Precedence levels:
-- **`medium`** — Component styles (from `styled()` and `useCSS()`)
-- **`low`** — Global styles (from `createGlobalStyle()`)
+Under the default precedence path, `getStyleTag()` and `getStyles()` return empty output because the buffer was never populated — every rule travelled through React 19's collected `<style precedence>` tags instead.
 
 ### @layer Support
 

--- a/content/docs/unistyle/responsive.mdx
+++ b/content/docs/unistyle/responsive.mdx
@@ -64,7 +64,7 @@ Explicit breakpoint assignment. Gaps filled by previous breakpoint:
 
 ## Transformation Pipeline
 
-The responsive engine applies 4 transformations:
+The responsive engine applies 5 transformations:
 
 ### 1. Normalize
 
@@ -125,7 +125,35 @@ Removes duplicate breakpoints with identical styles:
 // sm and lg removed — avoids duplicate @media blocks
 ```
 
-### 4. Media Query Wrapping
+### 4. Per-Breakpoint Delta Diff
+
+After each breakpoint's CSS is rendered, the cascade optimizer compares it to the running cascade and drops declarations whose `prop: value` is unchanged. Mobile-first `@media (min-width: …)` already inherits earlier declarations, so re-emitting them at every breakpoint is pure byte waste.
+
+```css
+/* Without delta diff — every breakpoint repeats every property */
+{ position: absolute; bottom: -4.375rem; right: -12.5rem; height: 28.75rem; }
+@media (min-width: 36em) {
+  position: absolute; bottom: -4.375rem; right: -11.25rem; height: 28.75rem;
+}
+@media (min-width: 48em) {
+  position: absolute; bottom: 0; right: -11.25rem; height: 40rem;
+}
+
+/* With delta diff — each breakpoint only emits what actually changed */
+{ position: absolute; bottom: -4.375rem; right: -12.5rem; height: 28.75rem; }
+@media (min-width: 36em) { right: -11.25rem; }
+@media (min-width: 48em) { bottom: 0; height: 40rem; }
+```
+
+The diff operates on the rendered CSS strings, parsing top-level declarations + opaque blocks (nested selectors / at-rules) with quote-, paren-, and brace-aware scanning. Selector blocks like `&:hover { … }` are deduped by exact text match.
+
+**Limitations** the optimizer doesn't model:
+- **Shorthand vs longhand** — if breakpoint A sets `padding: 1rem` and B sets `padding-top: 0`, both are kept (different `prop` keys). Conversely, B's `padding` shorthand is always emitted because it resets sides A didn't set.
+- **Whitespace-equivalent blocks** — `&:hover{color:red}` and `&:hover { color: red; }` would both be emitted.
+
+**Engine compatibility** — the diff runs on stringified results. If a styles callback returns an engine-specific object whose default `toString()` yields `[object Object]`, the optimizer bypasses and the original unoptimized path runs unchanged. Styler's `CSSResult.toString()` resolves with empty props, so styles callbacks that destructure theme at call-time (the project convention) work transparently.
+
+### 5. Media Query Wrapping
 
 Each remaining breakpoint gets wrapped in its media query:
 


### PR DESCRIPTION
## Summary

Sync docs with the two SSR/responsive changes shipped in ui-system 2.0.0-beta.3 / beta.4.

### styler/api.mdx — SSR pattern reorganized

- Lead with **React 19 \`<style precedence>\` as the default path** — no manual style collection needed. \`getStyleTag()\` / \`getStyles()\` are demoted to a "manual mode" callout because they return empty output under the default path.
- The reason: previously, styler was both emitting \`<style precedence>\` AND pushing into \`ssrBuffer\`, which caused every rule to appear twice in the DOM after hydration (vitus-labs/ui-system#181). The SSR buffer is now intentionally untouched on the default path.
- Updated the Hydration list to mention that \`mount()\` also pre-populates the dedup cache from \`<style data-precedence][data-href]>\` tags — that's what prevents the first \`useInsertionEffect\` from re-injecting a rule that's already in the DOM under a precedence tag.

### unistyle/responsive.mdx — pipeline now has 5 steps

Added "Per-Breakpoint Delta Diff" between Optimize and Media Query Wrapping (vitus-labs/ui-system#183). Covers:
- What the cascade optimizer does (drops declarations whose \`prop: value\` is unchanged from the running cascade)
- A real before/after CSS sample showing how the user's reported responsive Wrapper case collapses from re-emitting every property at every breakpoint to just the deltas
- Documented limitations (shorthand vs longhand, whitespace-equivalent blocks)
- Engine compatibility — the diff runs on stringified results; foreign-engine objects whose default \`toString()\` yields \`[object Object]\` bypass the optimizer and run the original path unchanged

## Notes

- Docs deps still pin \`^2.0.0-beta.1\`; they don't auto-pick up later prereleases. Happy to bump to \`^2.0.0-beta.4\` in a follow-up — out of scope for this content-only update.

## Test plan

- [x] \`bun run postinstall\` (fumadocs-mdx) — MDX validation clean
- [ ] \`bun run build\` — full Next build (pending review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)