### PR TITLE
chore(ci): add PR build check (foundation for auto-merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ['main']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+            .fumadocs-typescript-cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx', '**/*.mdx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
## Summary

Adds a CI workflow that runs `bun run build` on every PR to main. This is the foundation for enabling branch protection + auto-merge on this repo: the resulting `Build` status check is what protection will require, and what `allow_auto_merge` will wait for.

`bun run build` invokes `next build` which runs TypeScript checking, MDX compilation, and static page generation — covers the same ground I've been verifying manually before opening doc PRs (kinetic rewrite, audit sync, etc.).

Style matches the existing `nextjs.yml` deploy workflow (Bun, unpinned action versions, similar cache shape).

## Next steps after merge

1. Add branch protection on `main` requiring the `Build` check (via `gh api`).
2. Enable `allow_auto_merge` on the repo (currently `false`).
3. Future PRs can be marked `gh pr merge --auto --squash` and will land once the build passes.

## Test plan

- [x] Workflow file syntactically valid (will be confirmed when this PR's CI runs)
- [x] `bun run build` passes locally (used this same command for every recent docs PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)