### PR TITLE
docs: fix hero headline — React on new line, 'composable' → 'faster'

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -230,9 +230,9 @@ export default function HomePage() {
                 <h1 className="vl-hero-title">
                   Build, style
                   <br />
-                  &amp; <VerbRotator /> React
+                  &amp; <VerbRotator />
                   <br />
-                  apps <em>composable.</em>
+                  React apps <em>faster.</em>
                 </h1>
               </Reveal>
 


### PR DESCRIPTION
## Summary

Two-character tweak to the hero title that we caught after #18 merged.

Before (broken 3-line wrap, \"<verb> React\" ran together):
\`\`\`
Build, style
& <verb> React
apps composable.
\`\`\`

After:
\`\`\`
Build, style
& <verb>
React apps faster.
\`\`\`

Restores the original design's wrap, and \"faster.\" is closer to what the rotating verbs (ship/theme/test/animate/bundle) actually deliver than \"composable.\" did.

## Test plan

- [x] `bun run build` — clean
- [x] Reads naturally with each verb in the rotation