### PR TITLE
docs: revalidate counts — 122→123 presets, align styler minified figure

### DIFF
--- a/content/docs/kinetic-presets/index.mdx
+++ b/content/docs/kinetic-presets/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Kinetic Presets
-description: 122 ready-to-use animation presets, 5 customizable factories, and composition utilities for @vitus-labs/kinetic.
+description: 123 ready-to-use animation presets, 5 customizable factories, and composition utilities for @vitus-labs/kinetic.
 ---
 
-`@vitus-labs/kinetic-presets` provides a comprehensive library of 122 animation presets organized into 25 categories, plus 5 factory functions for creating custom presets and 5 composition utilities.
+`@vitus-labs/kinetic-presets` provides a comprehensive library of 123 animation presets organized into 25 categories, plus 5 factory functions for creating custom presets and 5 composition utilities.
 
 ## Installation
 
@@ -175,7 +175,7 @@ import { slideUp } from '@vitus-labs/kinetic-presets'
 
 ## Preset Categories
 
-All 122 presets are organized into 25 categories:
+All 123 presets are organized into 25 categories:
 
 | Category | Count | Examples |
 |----------|-------|---------|
@@ -343,11 +343,11 @@ const fadeUp = {
 }
 ```
 
-All 122 presets follow this symmetric pattern (leave reverses enter). The library uses a compact internal helper that generates both directions from a single pair of states, keeping the bundle small despite the large number of presets.
+All 123 presets follow this symmetric pattern (leave reverses enter). The library uses a compact internal helper that generates both directions from a single pair of states, keeping the bundle small despite the large number of presets.
 
 ## Tree-Shaking
 
-All 122 presets are individually exported for tree-shaking. Import only what you use:
+All 123 presets are individually exported for tree-shaking. Import only what you use:
 
 ```tsx
 // Only bundles fadeUp and scaleIn — everything else is eliminated
@@ -374,7 +374,7 @@ import {
   withDelay,
   reverse,
 
-  // All 122 presets (named exports)
+  // All 123 presets (named exports)
   fade,
   fadeUp,
   fadeDown,

--- a/content/docs/kinetic-presets/presets.mdx
+++ b/content/docs/kinetic-presets/presets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Presets Reference
-description: Complete reference of all 122 animation presets organized by category.
+description: Complete reference of all 123 animation presets organized by category.
 ---
 
 All presets define symmetric enter/leave animations. Enter animates from a hidden state to visible; leave reverses it. Each preset can be spread onto `<Transition>` or passed to `kinetic().preset()`.

--- a/content/docs/kinetic/api.mdx
+++ b/content/docs/kinetic/api.mdx
@@ -296,7 +296,7 @@ import {
 | `slideLeft` | Translate from right + fade |
 | `slideRight` | Translate from left + fade |
 
-For 122 additional presets, factory generators, and composition utilities, see [`@vitus-labs/kinetic-presets`](/docs/kinetic-presets).
+For 123 additional presets, factory generators, and composition utilities, see [`@vitus-labs/kinetic-presets`](/docs/kinetic-presets).
 
 ## Hooks
 

--- a/content/docs/kinetic/index.mdx
+++ b/content/docs/kinetic/index.mdx
@@ -409,7 +409,7 @@ import {
 const Panel = kinetic('aside').preset(slideRight)
 ```
 
-For 122 presets plus factory generators (`createSlide`, `createScale`, `createRotate`, `createFlip`, `createBounce`) and composition helpers, install [`@vitus-labs/kinetic-presets`](/docs/kinetic-presets).
+For 123 presets plus factory generators (`createSlide`, `createScale`, `createRotate`, `createFlip`, `createBounce`) and composition helpers, install [`@vitus-labs/kinetic-presets`](/docs/kinetic-presets).
 
 ## Hooks
 

--- a/content/docs/styler/index.mdx
+++ b/content/docs/styler/index.mdx
@@ -15,7 +15,7 @@ description: CSS-in-JS engine for Vitus Labs UI System — 4.82 KB gzipped, Reac
 
 ## Key Features
 
-- **4.82 KB gzipped** (13.65 KB minified, fresh build) — full SSR engine with `@layer`, at-rule splitting, and concurrent-mode-safe injection.
+- **4.82 KB gzipped** (12.21 KB minified, fresh build) — full SSR engine with `@layer`, at-rule splitting, and concurrent-mode-safe injection.
 - **Static/dynamic split** — templates with no function interpolations compute their class name once at module load; subsequent renders return a pre-built ReactElement with no resolve / hash / `createElement` work.
 - **FNV-1a hashing** — deterministic class names (`vl-<base36>`), automatic dedup. Hash loop is 4-char-unrolled for ~+15-46% throughput vs the per-char loop.
 - **CSS-in-CSS composition** — nest `css\`…\`` results inside `styled\`…\`` or other `css\`…\``. Static nested results are memoized per-instance (one resolve, reused across every consumer's render).
@@ -518,7 +518,7 @@ Fresh build of `@vitus-labs/styler` (rolldown, ESM, react externalized):
 | Build | Size |
 |---|---:|
 | Bundle (unminified) | 33.97 KB |
-| Minified | 13.65 KB |
+| Minified | 12.21 KB |
 | **Gzipped** | **4.82 KB** |
 
 Competitor numbers below are from each library's published artifact (read off bundlephobia / their dist files); they're a snapshot, not a regression-gated measurement:


### PR DESCRIPTION
## Summary

Revalidation pass against the source repo's ground truth.

- **kinetic-presets: "122 presets" → 123** across all references (the source `presets.ts` exports exactly 123). Updates the kinetic-presets index/presets pages and the kinetic index/api cross-links.
- **styler minified figure: 13.65 → 12.21 KB** to match the freshly-measured number now in the package README. The gzipped headline (**4.82 KB**) is unchanged — it's accurate (confirmed: full API, minified + gzipped, React external = 4.78 KB ≈ 4.82).

Audited and confirmed **correct, left unchanged**: 15 packages, 4.82 KB styler gz, 170+ CSS props, 28 hooks.

## Test plan
- [x] `bun run build` — clean (70 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)